### PR TITLE
Renaming product to 'Ticket Booth'

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-PRODUCT_NAME = 'Helping Culture'
+PRODUCT_NAME = 'Ticket Booth'


### PR DESCRIPTION
I've noticed that the product is still named "Helping Culture" on the frontend and its called TicketBooth on the backend. I'm unsure if this is intentional. 

<img width="643" alt="image" src="https://user-images.githubusercontent.com/1328337/167242067-30db33be-7476-4d13-84ba-ca12c61041c5.png">

If it's not intentional, I'm changing the product name to be consistent. If it is intentional, you can ignore this PR. 

## Reviewers
@mike-matera
@kigster