### PR TITLE
Update EA/LD contact information

### DIFF
--- a/app/views/eald_payments/new.html.haml
+++ b/app/views/eald_payments/new.html.haml
@@ -15,7 +15,7 @@
 
 %p
   Have questions? Feel free to send
-  = link_to 'Yarun', 'mailto:yarunl@gmail.com'
+  = link_to 'EA/LD', 'mailto:ealdfnf@gmail.com'
   a message!
 
 %hr


### PR DESCRIPTION
I'm no longer doing EA/LD, but I'm currently listed as the contact person. I'm changing the contact to the EA/LD group email address. If we do find someone willing to do EA/LD, I'll share the group email password with them. In the mean time, I can provide some light support for EA/LD via the EA/LD group email address. 

## Reviewers
@kigster , @mike-matera 