### PR TITLE
Use CloudSQL and External Secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@
 /vendor/bundle
 Downloads
 newrelic_agent.log
+.terraform*

--- a/deployment/chart/Chart.yaml
+++ b/deployment/chart/Chart.yaml
@@ -15,15 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "3.0.0"
-
-dependencies:
-  - name: postgresql 
-    version: "11"
-    repository: "https://charts.bitnami.com/bitnami"

--- a/deployment/chart/templates/config.yaml
+++ b/deployment/chart/templates/config.yaml
@@ -4,13 +4,16 @@ metadata:
   name: {{ .Release.Name }}-config
 data:
   {{ .Values.config | nindent 2 }}
----
 {{- if .Values.secret.create }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ default {{ .Release.Name }}"-secrets" .Values.secret.name }}
-type: Opaque
+{{- if .Values.secret.name }}
+  name: {{ .Values.secret.name }}
+{{- else }}
+  name: {{ .Release.Name }}"-secrets"type: Opaque
+{{- end }}
 stringData:
   {{ .Values.secret.data | nindent 2 }}
 {{- end }}

--- a/deployment/chart/templates/config.yaml
+++ b/deployment/chart/templates/config.yaml
@@ -3,25 +3,14 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config
 data:
-  RAILS_ENV: "{{ .Values.ticketsEnvironment }}"
-  SMTP_ADDRESS: "{{ .Values.ticketsSMTPHost }}"
-  SMTP_PORT: "{{ .Values.ticketsSMTPPort }}"
-  SMTP_DOMAIN: "{{ .Values.ticketsSMTPDomain }}"
-  TICKETS_HOST: "{{ .Values.ticketsHost }}"
-  ACTION_MAILER_DEFAULT_FROM: "{{ .Values.ticketsEmailAddress }}"
-  ACTION_MAILER_DEFAULT_TO: "{{ .Values.ticketsEmailAddress }}"
-  STRIPE_PUBLIC_KEY: "{{ .Values.stripePublicKey }}"
-  WEB_CONCURRENCY: "{{ .Values.pumaConcurrency }}"
-  RAILS_MAX_THREADS: "{{ .Values.pumaThreads }}"
+  {{ .Values.config | nindent 2 }}
 ---
+{{- if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secrets
+  name: {{ default {{ .Release.Name }}"-secrets" .Values.secret.name }}
 type: Opaque
 stringData:
-  SECRET_KEY_BASE: "{{ .Values.ticketsSecretToken }}"
-  RAILS_SERVE_STATIC_FILES: "{{ .Values.ticketsServeStaticFiles }}"
-  SMTP_USERNAME: "{{ .Values.ticketsSMTPUser }}"
-  SMTP_PASSWORD: "{{ .Values.ticketsSMTPPassword }}"
-  STRIPE_SECRET_KEY: "{{ .Values.stripeSecretKey }}"
+  {{ .Values.secret.data | nindent 2 }}
+{{- end }}

--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -50,31 +50,41 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          # These should really come from a autogenerate value
-          - name: TICKET_DB_HOST
-            value: {{ include "chart.postgresql.fullname" . }}
-          - name: TICKET_DB_PORT
-            value: "5432"
-          - name: TICKET_DB_NAME
-            value: {{ .Values.postgresql.auth.database }}
-          - name: TICKET_DB_USER
-            value: {{ .Values.postgresql.auth.username }}
-          - name: TICKET_DB_PASSWORD
-            value: {{ .Values.postgresql.auth.password }}
+            # These should really come from a autogenerate value
+            - name: TICKET_DB_HOST
+              value: 127.0.0.1
+            - name: TICKET_DB_PORT
+              value: "5432"
+            - name: TICKET_DB_NAME
+              value: {{ .Values.postgresql.database }}
           envFrom:
-          - secretRef:
-              name: {{ default {{ .Release.Name }}"-secrets" .Value.secrets.name }}
-          - configMapRef:
+            - secretRef:
+            {{- if .Value.secret.name }}
+              name: {{ .Value.secret.name }}
+            {{- else }}
+              name: {{ .Release.Name }}-secrets
+            {{- end }}
+            - configMapRef:
               name: {{ .Release.Name }}-config
           # Fix for: https://github.com/puma/puma/issues/2343
           lifecycle:
             preStop:
               exec:
                 command: ['/bin/sh', '-c', 'sleep 15']
-      initContainers:
-      - name: init-wait-db
-        image: busybox:1.31
-        command: ['sh', '-c', 'echo -e "Checking for the availability of Postgres Server deployment"; while ! nc -z {{ .Release.Name }}-postgresql.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local 5432; do sleep 10; printf "-"; done; echo -e "  >> DB Server has started";']
+        - name: cloud-sql-proxy
+          image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0
+          args:
+            - "--private-ip"
+            - "--structured-logs"
+            - "--port=5432"
+            - "--auto-iam-authn"
+            - {{ .Values.postgresql.instance }}
+          securityContext:
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "2Gi"
+              cpu:    "1"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+          # These should really come from a autogenerate value
           - name: TICKET_DB_HOST
             value: {{ include "chart.postgresql.fullname" . }}
           - name: TICKET_DB_PORT
@@ -62,7 +63,7 @@ spec:
             value: {{ .Values.postgresql.auth.password }}
           envFrom:
           - secretRef:
-              name: {{ .Release.Name }}-secrets
+              name: {{ default {{ .Release.Name }}"-secrets" .Value.secrets.name }}
           - configMapRef:
               name: {{ .Release.Name }}-config
           # Fix for: https://github.com/puma/puma/issues/2343

--- a/deployment/chart/templates/external_secret.yaml
+++ b/deployment/chart/templates/external_secret.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secret.external.enabled }}
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.secret.name }}
+spec:
+  secretStoreRef:
+{{- .Values.storeRef | toYaml | nindent 4 }}
+  target:
+    name: {{ .Values.secret.name }}
+    creationPolicy: Merge
+  template:
+    type: Opaque
+  dataFrom:
+    - key: {{ .Values.secrets.external.path }}
+{{- end }}

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -88,11 +88,15 @@ secret:
   # someplace. Do this only with non-production resources.
   create: false
 
-  # Any secrets should be contained within GCP Se
+  # Any secrets should be contained within GCP Secrets and pulled in by ExternalSecrets
+  name: ""
 
-  # The name of the secret to use.
-  # Default: {{ .Release.Name }}-secrets
-  #name: ""
+  external:
+    enabled: false
+    path: ""
+    storeRef:
+      name: ""
+      kind: ""
 
   # Data to put into a created secret. Does not need to be base64 encoded
   # data:
@@ -101,12 +105,9 @@ secret:
   #  ticketsSMTPUser: ""
   #  ticketsSMTPPassword: ""
   #  stripeSecretKey: ""
-    
-
   
 postgresql:
-  auth:
-    database: tickets
-    username: ticketsuser
-    password: ""
-    postgresPassword: ""
+  # The postgres DB will normally be connected to via IAM and CloudSQL Proxy and
+  # therefore all we need is the name of the CloudSQL instance and database name.
+  database: tickets
+  instance: null

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -71,22 +71,39 @@ tolerations: []
 
 affinity: {}
 
-ticketsEnvironment: "production"
-ticketsSecretToken: "this-is-a-very-bogus-key"
-ticketsServeStaticFiles: "true"
-ticketsSMTPHost: ""
-ticketsSMTPPort: "" 
-ticketsSMTPDomain: ""
-ticketsSMTPUser: ""
-ticketsSMTPPassword: ""
-ticketsDBSeed: ""
-ticketsHost: ""
-ticketsEmailAddress: ""
-stripeSecretKey: ""
-stripePublicKey: ""
-pumaConcurrency: 2
-pumaThreads: 2
+config:
+  ticketsEnvironment: "production"
+  ticketsSMTPHost: ""
+  ticketsSMTPPort: "" 
+  ticketsSMTPDomain: ""
+  ticketsDBSeed: ""
+  ticketsHost: ""
+  ticketsEmailAddress: ""
+  stripePublicKey: ""
+  pumaConcurrency: 2
+  pumaThreads: 2
 
+secret:
+  # The secret should never be created with Helm because the values get stored
+  # someplace. Do this only with non-production resources.
+  create: false
+
+  # Any secrets should be contained within GCP Se
+
+  # The name of the secret to use.
+  # Default: {{ .Release.Name }}-secrets
+  #name: ""
+
+  # Data to put into a created secret. Does not need to be base64 encoded
+  # data:
+  #  ticketsSecretToken: "this-is-a-very-bogus-key"
+  #  ticketsServeStaticFiles: "true"
+  #  ticketsSMTPUser: ""
+  #  ticketsSMTPPassword: ""
+  #  stripeSecretKey: ""
+    
+
+  
 postgresql:
   auth:
     database: tickets

--- a/deployment/env/base.yaml
+++ b/deployment/env/base.yaml
@@ -17,3 +17,9 @@ ingress:
     # Associate a GCP FrontendConfig with the Ingress
     # networking.gke.io/v1beta1.FrontendConfig: "<name>"
 
+# The secret should be defined in the environment file
+secrets:
+  create: false
+
+podSecurityContext:
+  runAsNonRoot: true

--- a/deployment/env/base.yaml
+++ b/deployment/env/base.yaml
@@ -1,0 +1,19 @@
+---
+image:
+  pullPolicy: Always
+
+serviceAccount:
+  create: true
+
+service:
+  type: NodePort
+  port: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/ingress.allow-http: "false"
+    # Associate a GCP FrontendConfig with the Ingress
+    # networking.gke.io/v1beta1.FrontendConfig: "<name>"
+

--- a/deployment/env/production.yaml
+++ b/deployment/env/production.yaml
@@ -1,0 +1,14 @@
+---
+replicaCount: 3
+
+image:
+  # The tag should be provided on the cmdline to prevent accidental deployments
+  # of untesed code to production.
+  tag: null
+
+serviceAccount:
+  annotations:
+    # Any secrets should be contained within GCP managed secrets, so an IAM
+    # ServiceAccount is needed that has the permissions to read from the named
+    # secret
+    iam.gke.io/gcp-service-account: ticket-app-sa@fnf-apps-project.iam.gserviceaccount.com

--- a/deployment/env/production.yaml
+++ b/deployment/env/production.yaml
@@ -4,7 +4,7 @@ replicaCount: 3
 image:
   # The tag should be provided on the cmdline to prevent accidental deployments
   # of untesed code to production.
-  tag: null
+  tag: latest
 
 serviceAccount:
   annotations:
@@ -12,3 +12,16 @@ serviceAccount:
     # ServiceAccount is needed that has the permissions to read from the named
     # secret
     iam.gke.io/gcp-service-account: ticket-app-sa@fnf-apps-project.iam.gserviceaccount.com
+
+secret:
+  name: ticket-booth-app-secrets
+  external:
+    enabled: true
+    path: ticket-booth-app-secret
+    storeRef:
+      name: fnf-external-secrets
+      kind: ClusterSecretStore
+
+postgresql:
+  # Get this value from the Terraform output
+  instance: fnf-apps-db-instance

--- a/deployment/gcp/iam.tf
+++ b/deployment/gcp/iam.tf
@@ -31,8 +31,6 @@ resource "google_service_account_iam_binding" "ticket_booth_app" {
   role               = google_project_iam_custom_role.ticket_booth.name
 
   members = [
-    "serviceAccount:${google_service_account.ticket_booth_gke.name}",
+    "serviceAccount:${var.project_id}.svc.id.goog[${var.app_namespace}/${var.app_service_account}]",
   ]
 }
-
-

--- a/deployment/gcp/iam.tf
+++ b/deployment/gcp/iam.tf
@@ -1,0 +1,38 @@
+# IAM roles and permissions for the app to talk to external GCP services
+resource "google_project_iam_custom_role" "ticket_booth" {
+  role_id     = "fnfTicketBoothAppRole"
+  title       = "Fnf Ticket Booth App Role"
+  description = "Role that provides all the permissions needed by the app"
+  permissions = [
+    "cloudsql.databases.get",
+    "cloudsql.databases.create",
+    "cloudsql.databases.delete",
+    "cloudsql.databases.get",
+    "cloudsql.databases.update",
+    "cloudsql.instances.connect",
+    "cloudsql.instances.executeSql",
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.getAccessToken",
+    "iam.serviceAccounts.getOpenIdToken",
+    "iam.serviceAccounts.list",
+  ]
+}
+
+resource "google_service_account" "ticket_booth_gke" {
+  account_id   = var.project_id
+  description  = "Ticket Booth GKE Service Account"
+  display_name = "ticket-booth-gke"
+
+  create_ignore_already_exists = true
+}
+
+resource "google_service_account_iam_binding" "ticket_booth_app" {
+  service_account_id = google_service_account.ticket_booth_gke.name
+  role               = google_project_iam_custom_role.ticket_booth.name
+
+  members = [
+    "serviceAccount:${google_service_account.ticket_booth_gke.name}",
+  ]
+}
+
+

--- a/deployment/gcp/secrets.tf
+++ b/deployment/gcp/secrets.tf
@@ -1,0 +1,28 @@
+# This creates the secret store locations, entries will need to be manually updated
+
+resource "google_secret_manager_secret" "ticket_booth_db" {
+  secret_id = "ticket-booth-db"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "ticket_booth_db" {
+  secret = google_secret_manager_secret.ticket_booth_db.id
+
+  secret_data = base64encode(jsonencode({
+    "TICKET_DB_HOST"     = tostring(google_sql_database_instance.ticket_booth.connection_name)
+    "TICKET_DB_NAME"     = tostring(google_sql_database.ticket_booth.name)
+    "TICKET_DB_USER"     = "fnf-breakglass"
+    "TICKET_DB_PASSWORD" = tostring(random_password.ticket_booth_db.result)
+  }))
+}
+
+resource "google_secret_manager_secret" "ticket_booth_app" {
+  secret_id = "ticket-booth-app"
+
+  replication {
+    auto {}
+  }
+}

--- a/deployment/gcp/sql.tf
+++ b/deployment/gcp/sql.tf
@@ -1,6 +1,7 @@
 locals {
   db_admins = [
     "evilmonkey@gmail.com",
+    "matt@fnf.org",
   ]
 }
 
@@ -40,8 +41,12 @@ resource "google_sql_database_instance" "ticket_booth" {
   }
 }
 
+output "ticket_db_instance_name" {
+  value = google.sql_database_instance.ticket_booth.name
+}
+
 resource "google_sql_database" "ticket_booth" {
-  name     = "ticket-booth"
+  name     = "tickets"
   instance = google_sql_database_instance.ticket_booth.name
 }
 
@@ -49,7 +54,7 @@ resource "google_sql_user" "fnf_apps_admin_users" {
   for_each = toset(local.db_admins)
   name     = each.value
   instance = google_sql_database_instance.ticket_booth.name
-  type     = "CLOUD_IAM_GROUP"
+  type     = "CLOUD_IAM_USER"
 }
 
 resource "google_sql_user" "fnf_apps_gke_sa" {
@@ -69,4 +74,3 @@ resource "random_password" "ticket_booth_db" {
   special          = true
   override_special = "!#$%&*()-_=+[]{}<>:?"
 }
-

--- a/deployment/gcp/sql.tf
+++ b/deployment/gcp/sql.tf
@@ -1,0 +1,72 @@
+locals {
+  db_admins = [
+    "evilmonkey@gmail.com",
+  ]
+}
+
+resource "google_sql_database_instance" "ticket_booth" {
+  name             = "fnf-apps-db-instance"
+  database_version = "POSTGRES_15"
+  region           = var.location
+
+  settings {
+    tier = "e2-small"
+
+    # Only allow access from the GKE cluster
+    ip_configuration {
+      enable_private_path_for_google_cloud_services = true
+      #  authorized_networks {
+      #    name = ""
+      #    value = ""
+      #  }
+    }
+
+    database_flags {
+      name  = "cloudsql.iam_authentication"
+      value = "on"
+    }
+
+    activation_policy           = "ON_DEMAND"
+    deletion_protection_enabled = true
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+
+      backup_retention_settings {
+        retained_backups = 10
+      }
+    }
+  }
+}
+
+resource "google_sql_database" "ticket_booth" {
+  name     = "ticket-booth"
+  instance = google_sql_database_instance.ticket_booth.name
+}
+
+resource "google_sql_user" "fnf_apps_admin_users" {
+  for_each = toset(local.db_admins)
+  name     = each.value
+  instance = google_sql_database_instance.ticket_booth.name
+  type     = "CLOUD_IAM_GROUP"
+}
+
+resource "google_sql_user" "fnf_apps_gke_sa" {
+  name     = trimsuffix(google_service_account.ticket_booth_gke.email, ".gserviceaccount.com")
+  instance = google_sql_database_instance.ticket_booth.name
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+}
+
+resource "google_sql_user" "breakglass" {
+  name     = "fnf-breakglass"
+  instance = google_sql_database_instance.ticket_booth.name
+  password = random_password.ticket_booth_db.result
+}
+
+resource "random_password" "ticket_booth_db" {
+  length           = 20
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+

--- a/deployment/gcp/terraform.tf
+++ b/deployment/gcp/terraform.tf
@@ -1,0 +1,19 @@
+terraform {
+  backend "gcs" {
+    bucket = "fnf-apps-terraform-state"
+    prefix = "ticket-booth"
+  }
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "5.25.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.location
+
+  impersonate_service_account = var.tf_service_account != "" ? var.tf_service_account : ""
+}

--- a/deployment/gcp/variables.tf
+++ b/deployment/gcp/variables.tf
@@ -1,0 +1,14 @@
+variable "tf_service_account" {
+  default = "sa-cluster@fnf-apps-341500.iam.gserviceaccount.com"
+  type    = string
+}
+
+variable "project_id" {
+  default = "fnf-apps-341500"
+  type    = string
+}
+
+variable "location" {
+  default = "us-central1"
+  type    = string
+}

--- a/deployment/gcp/variables.tf
+++ b/deployment/gcp/variables.tf
@@ -1,5 +1,17 @@
-variable "tf_service_account" {
-  default = "sa-cluster@fnf-apps-341500.iam.gserviceaccount.com"
+variable "app_namespace" {
+  default     = "default"
+  description = "GKE namespace where the app is deployed"
+  type        = string
+}
+
+variable "app_service_account" {
+  default     = "ticket-booth-sa"
+  description = "The GKE ServiceAccount used by the app"
+  type        = string
+}
+
+variable "location" {
+  default = "us-central1"
   type    = string
 }
 
@@ -8,7 +20,8 @@ variable "project_id" {
   type    = string
 }
 
-variable "location" {
-  default = "us-central1"
+variable "tf_service_account" {
+  default = "sa-cluster@fnf-apps-341500.iam.gserviceaccount.com"
   type    = string
 }
+


### PR DESCRIPTION
Changed the sidecar to run a CloudSQL Proxy
Using the WorkloadIdentity to access GCP resources

External secret to get the other non-db related things working.

This will allow us to run more than 1 replica