### PR TITLE
Adding default values to Event creation

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,7 +23,7 @@ class EventsController < ApplicationController
   end
 
   def new
-    @event = Event.new
+    @event = Event.new(Event::DEFAULT_ATTRIBUTES)
   end
 
   def edit

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -72,12 +72,12 @@ class Event < ApplicationRecord
            :ensure_prices_set_if_maximum_specified
 
   DEFAULT_ATTRIBUTES = {
-    adult_ticket_price: 150,
+    adult_ticket_price: 250,
     early_arrival_price: 20,
-    kid_ticket_price: 50,
+    kid_ticket_price: 0,
     late_departure_price: 20,
-    max_adult_tickets_per_request: 4,
-    max_kid_tickets_per_request: 2,
+    max_adult_tickets_per_request: 10,
+    max_kid_tickets_per_request: 4,
     max_cabins_per_request: 1,
     max_cabin_requests: 2,
     tickets_require_approval: true,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,6 +71,21 @@ class Event < ApplicationRecord
   validate :end_time_after_start_time, :sales_end_time_after_start_time,
            :ensure_prices_set_if_maximum_specified
 
+  DEFAULT_ATTRIBUTES = {
+    adult_ticket_price: 150,
+    early_arrival_price: 20,
+    kid_ticket_price: 50,
+    late_departure_price: 20,
+    max_adult_tickets_per_request: 4,
+    max_kid_tickets_per_request: 2,
+    max_cabins_per_request: 1,
+    max_cabin_requests: 2,
+    tickets_require_approval: true,
+    require_mailing_address: false,
+    allow_financial_assistance: true,
+    allow_donations: true
+  }.freeze
+
   def admin?(user)
     user && (user.site_admin? || admins.exists?(id: user))
   end


### PR DESCRIPTION
When creating a new event, some fields are now auto-populated with default values.