### PR TITLE
Update kids policy

### DIFF
--- a/app/views/ticket_requests/_form.html.haml
+++ b/app/views/ticket_requests/_form.html.haml
@@ -146,7 +146,7 @@
                   - if @event.kid_ticket_price
 
                     = f.label :kids do
-                      Number of children (13 or under) you are bringing with you (not transferable to adults; babes in arms are free)
+                      Number of children (12 and under) you are bringing with you (not transferable to adults; babes in arms are free)
                       = help_mark help_text_for(:kids)
 
                     = f.number_field :kids, class: 'input-mini', min: 0,


### PR DESCRIPTION
Updating the copy to be consistent with the Kid's policy. Only Kids 12 and under can join for free. 

https://fnf.events/tickets-information-2024/