### PR TITLE
Adding Download ALL vs Active CSV Button

### DIFF
--- a/app/controllers/ticket_requests_controller.rb
+++ b/app/controllers/ticket_requests_controller.rb
@@ -38,12 +38,14 @@ class TicketRequestsController < ApplicationController
   end
 
   def download
+    download_type = permitted_params[:type] || :active
+
     csv_file = Tempfile.new('csv')
 
     CSV.open(csv_file.path, 'w',
              write_headers: true,
              headers: TicketRequest.csv_header) do |csv|
-      TicketRequest.for_csv(@event).each do |row|
+      TicketRequest.for_csv(@event, type: download_type).each do |row|
         csv << row
       end
     end
@@ -261,6 +263,7 @@ class TicketRequestsController < ApplicationController
       :password,
       :authenticity_token,
       :commit,
+      :type,
       :_method,
       ticket_request: [
         :user_id,

--- a/app/views/ticket_requests/_table_ticket_request_statuses.html.haml
+++ b/app/views/ticket_requests/_table_ticket_request_statuses.html.haml
@@ -2,9 +2,12 @@
 .card
   .card-header.bg-primary-subtle
     .btn-group.fs-5
-      = link_to download_event_ticket_requests_path(event), class: 'btn btn-warning ' do
+      = link_to download_event_ticket_requests_path(event, type: "active"), class: 'btn btn-warning ' do
         %i.icon-th-list
-        Download CSV ▼
+        Download CSV of Approved ▼
+      = link_to download_event_ticket_requests_path(event, type: "all"), class: 'btn btn-warning ' do
+        %i.icon-th-list
+        Download CSV of All ▼
   .card-body
     .vertical-20
 


### PR DESCRIPTION

Can now download either just approved (paid and waiting for payment) Ticket Requests (aka "active") as well as all non-cancelled requests ("all").

<img width="770" alt="image" src="https://github.com/fnf-org/TicketBooth/assets/259982/4d5f8d9c-7056-4fdb-87da-118f54d12d49">
