### PR TITLE
Add csv and logger gems to remove warnings

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Restore node_modules
         uses: actions/cache@v4
         with:
-        path: '**/node_modules'
+          path: '**/node_modules'
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
 
       - uses: ruby/setup-ruby@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -74,4 +74,5 @@ jobs:
           bin/rails db:test:prepare
 
       - name: "Run Rspec"
-        run: bundle exec rspec --backtrace --force-color
+        run: bundle exec rspec --backtrace --force-color --format documentation
+

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -74,4 +74,4 @@ jobs:
           bin/rails db:test:prepare
 
       - name: "Run Rspec"
-        run: bundle exec rspec --format documentation -p 0 --backtrace --force-color
+        run: bundle exec rspec --backtrace --force-color

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -74,4 +74,4 @@ jobs:
           bin/rails db:test:prepare
 
       - name: "Run Rspec"
-        run: bundle exec rspec
+        run: bundle exec rspec --format documentation -p 0 --backtrace --force-color

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -54,6 +54,12 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Restore node_modules
+        uses: actions/cache@v4
+        with:
+        path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3.5'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -80,5 +80,5 @@ jobs:
           bin/rails db:test:prepare
 
       - name: "Run Rspec"
-        run: bundle exec rspec --backtrace --force-color --format documentation
+        run: time bundle exec rspec --backtrace --force-color --format documentation
 

--- a/.rspec
+++ b/.rspec
@@ -1,5 +1,6 @@
 --format progress
+--force-color
 --color
 --order rand
---profile 5
+--profile 3
 --require rails_helper

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,10 @@ gem 'cssbundling-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
+# Gems that used to be in Standard Library, but are no longer
+gem 'csv'     # removed from stdlib with ruby 3.4
+gem 'logger'  # removed from stdlib with ruby 3.5
+
 # Redis
 gem 'redis' # , '>= 4.0.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.0)
     dalli (3.2.8)
     data_migrate (11.0.0)
       activerecord (>= 6.1)
@@ -200,6 +201,7 @@ GEM
       railties (>= 6.0.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.1)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -478,6 +480,7 @@ DEPENDENCIES
   colorize
   country_select
   cssbundling-rails
+  csv
   dalli
   data_migrate
   debug
@@ -492,6 +495,7 @@ DEPENDENCIES
   hashie
   jbuilder
   jsbundling-rails
+  logger
   lograge
   logstash-event
   mini_magick

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,11 +8,6 @@ require File.expand_path('../config/environment', __dir__)
 
 require 'rspec/rails'
 require 'accept_values_for'
-require 'timeout'
-
-def example_with_timeout(example)
-  Timeout.timeout(30) { example.run }
-end
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
@@ -24,8 +19,6 @@ RSpec.configure do |config|
   config.after :example, :ventable_disabled do
     Ventable.enable
   end
-
-  config.around { |example| example_with_timeout(example) }
 
   config.use_transactional_fixtures = true
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,10 @@ RSpec.configure do |config|
   config.expect_with(:rspec) do |c|
     c.syntax = %i[should expect]
   end
+
+  config.around do |example|
+    Timeout.timeout(5) do
+      example.run
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
+ENV['RAILS_ENV'] = 'test'
+
 # Enable YJIT if we have it compiled in
 if defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enable)
-  RubyVM::YJIT.enable
-  puts '[ ✔ ] YJIT is enabled'
+  RubyVM::YJIT.enabled? ? warn('[ 𐄂 ] YJIT is enabled') : warn('[ 𐄂 ] YJIT is disabled')
+  # uncomment when we determine if the spec failures are due to YJIT
+  # RubyVM::YJIT.enable
+  # puts '[ ✔ ] YJIT is enabled'
 else
   warn '[ 𐄂 ] YJIT is not enabled'
 end
-
-ENV['RAILS_ENV'] = 'test'
 
 require 'simplecov'
 SimpleCov.start 'rails'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,9 @@
 
 ENV['RAILS_ENV'] = 'test'
 
+$stdout.sync = true
+$stderr.sync = true
+
 # Enable YJIT if we have it compiled in
 if defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enable)
   RubyVM::YJIT.enabled? ? warn('[ 𐄂 ] YJIT is enabled') : warn('[ 𐄂 ] YJIT is disabled')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,10 +7,8 @@ $stderr.sync = true
 
 # Enable YJIT if we have it compiled in
 if defined?(RubyVM::YJIT) && RubyVM::YJIT.respond_to?(:enable)
-  RubyVM::YJIT.enabled? ? warn('[ 𐄂 ] YJIT is enabled') : warn('[ 𐄂 ] YJIT is disabled')
-  # uncomment when we determine if the spec failures are due to YJIT
-  # RubyVM::YJIT.enable
-  # puts '[ ✔ ] YJIT is enabled'
+  RubyVM::YJIT.enable
+  puts '[ ✔ ] YJIT is enabled'
 else
   warn '[ 𐄂 ] YJIT is not enabled'
 end
@@ -29,7 +27,8 @@ RSpec.configure do |config|
   end
 
   config.around do |example|
-    Timeout.timeout(5) do
+    # 10 seconds should be more than enough for ANY spec
+    Timeout.timeout(ENV.fetch('RSPEC_TIMEOUT', 10).to_i) do
       example.run
     end
   end


### PR DESCRIPTION
Fixing two warnings:

```
warning: /Users/kig/.rbenv/versions/3.3.5/lib/ruby/3.3.0/logger.rb 
was loaded from the standard library, but will no longer be part 
of the default gems starting from Ruby 3.5.0.
```